### PR TITLE
Put resolved path for load-themed-styles.

### DIFF
--- a/src/SassTask.ts
+++ b/src/SassTask.ts
@@ -164,7 +164,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
             ];
           } else if (!!content) {
             lines = [
-              'import { loadStyles } from \'load-themed-styles\';',
+              `import { loadStyles } from ${JSON.stringify(require.resolve('load-themed-styles'))};`,
               '',
               exportClassNames,
               '',


### PR DESCRIPTION
The dependent project does not need to declare `load-themed-styles` as its dependencies.